### PR TITLE
テキストエリアの表示位置を選択できる機能の追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
         <div id="video_wrapper" class="video_wrapper">
             <video id="result_video" class="video_area" autoplay></video>
             <div id="bg_green" class="bg_green hidden"></div>
-            <div class="text_overlay">
+            <div id="result_text_overlay" class="text_overlay">
                 <div id="result_text" class="text_area">音声認識が始まるとここに文字が表示されます。マイクとカメラを有効にしてください。</div>
             </div>
             <!-- <input type="button" id="FullScreenBtn" class="FullScreenBtn" value="全画面"> -->
@@ -65,6 +65,35 @@
                     oninput="document.getElementById('result_text').style.color=this.value,document.getElementById('value_font_color').innerHTML=this.value">
                 <div class="control_value">
                     <span id="value_font_color">#ffffff</span>
+                </div>
+
+                <label for="selector_position" class="control_label">位置</label>
+                <div class="control_input">
+                <input id="selector_position" type="radio" name='selector_position'
+                    oninput="document.getElementById('result_text_overlay').style.width='80%',document.getElementById('result_text_overlay').style.height='80%',
+                    document.getElementById('result_text_overlay').style.top='10%',document.getElementById('result_text_overlay').style.left='10%',
+                    document.getElementById('result_text_overlay').style.right='10%',document.getElementById('result_text_overlay').style.bottom='10%',
+                    document.getElementById('result_text').style.backgroundColor='rgba(0,0,0,0.0)'" checked> 全体
+                <input id="selector_position" type="radio" name='selector_position'
+                    oninput="document.getElementById('result_text_overlay').style.width='50%',document.getElementById('result_text_overlay').style.height='80%',
+                    document.getElementById('result_text_overlay').style.top='10%',document.getElementById('result_text_overlay').style.left='10%',
+                    document.getElementById('result_text_overlay').style.right='40%',document.getElementById('result_text_overlay').style.bottom='10%',
+                    document.getElementById('result_text').style.backgroundColor='rgba(0,0,0,0.3)'"> 左
+                <input id="selector_position" type="radio"  name='selector_position'
+                    oninput="document.getElementById('result_text_overlay').style.width='50%',document.getElementById('result_text_overlay').style.height='80%',
+                    document.getElementById('result_text_overlay').style.top='10%',document.getElementById('result_text_overlay').style.left='40%',
+                    document.getElementById('result_text_overlay').style.right='40%',document.getElementById('result_text_overlay').style.bottom='10%',
+                    document.getElementById('result_text').style.backgroundColor='rgba(0,0,0,0.3)'"> 右
+                <input id="selector_position" type="radio" name='selector_position'
+                    oninput="document.getElementById('result_text_overlay').style.width='80%',document.getElementById('result_text_overlay').style.height='40%',
+                    document.getElementById('result_text_overlay').style.top='10%',document.getElementById('result_text_overlay').style.left='10%',
+                    document.getElementById('result_text_overlay').style.right='10%',document.getElementById('result_text_overlay').style.bottom='50%',
+                    document.getElementById('result_text').style.backgroundColor='rgba(0,0,0,0.3)'"> 上
+                <input id="selector_position" type="radio" name='selector_position'
+                    oninput="document.getElementById('result_text_overlay').style.width='80%',document.getElementById('result_text_overlay').style.height='40%',
+                    document.getElementById('result_text_overlay').style.top='50%',document.getElementById('result_text_overlay').style.left='10%',
+                    document.getElementById('result_text_overlay').style.right='10%',document.getElementById('result_text_overlay').style.bottom='10%',
+                    document.getElementById('result_text').style.backgroundColor='rgba(0,0,0,0.3)'"> 下
                 </div>
             </form>
             <input type="button" value="カメラ表示/非表示"

--- a/style.css
+++ b/style.css
@@ -55,11 +55,10 @@ a:link, a:visited, a:hover, a:active {
 	position: absolute;
 	width: 80%;
 	height: 80%;
-	top: 0;
-	left: 0;
-	right: 0;
-	bottom: 0;
-	margin: auto;
+	top: 10%;
+	left: 10%;
+	right: 10%;
+	bottom: 10%;
 	overflow: hidden;
 }
 
@@ -79,6 +78,7 @@ a:link, a:visited, a:hover, a:active {
 	-webkit-text-stroke-color: #000;
 	text-align: justify;
 	opacity: 0.9;
+	background-color: rgba(0,0,0,0);
 }
 
 #status {
@@ -124,7 +124,7 @@ a:link, a:visited, a:hover, a:active {
 .control_form {
 	width: 400px;
 	display: grid;
-	grid-template-columns: 50px 200px 1fr;
+	grid-template-columns: 50px 250px 1fr;
 	grid-gap: 0rem 1rem;
 }
 


### PR DESCRIPTION
テキストエリアの位置を選択（全体/左/右/上/下）できる機能を追加しました。
また，全体以外の場合は text_area の背景の透過率を下げています。

UI は，スライダーをこれ以上増やさないために決め打ちの値のみとしました。なお，radio ボタンで作ったために項目が横に伸びてしまったので，control_form を 50px だけ拡げました。これに伴って form の他の UI も拡がっているので，適宜調整お願いします。

（サイズはかなり大きめですが，これ以上小さいものをデフォルトにしてしまうと，「文字を見せる」という目的に鑑みて本末転倒な状況になりかねないと思い，少々ダサいかもしれませんがこれくらいにしておきました。適宜調整お願いします。）