### PR TITLE
字幕が突然短くなってしまうのを改善する

### DIFF
--- a/index.html
+++ b/index.html
@@ -234,7 +234,7 @@
   <script src="kuromoji/build/kuromoji.js" defer></script>
   <!-- Chrome で MediaDevices.enumerateDevices() を動かすためのpolyfill -->
   <script src="https://webrtc.github.io/adapter/adapter-latest.js" defer></script>
-  <script src="./main.js" defer></script>
+  <script src="./main.js?v=202109230545" defer></script>
 </body>
 
 </html>

--- a/main.js
+++ b/main.js
@@ -154,6 +154,7 @@ navigator.mediaDevices.enumerateDevices()
 var flag_speech = 0;
 var recognition;
 var lang = 'ja-JP';
+var last_finished = ''; // 最後に確定した部分。確定部分が瞬時に消えるのを防ぐためにここで定義。
 var textUpdateTimeoutID = 0;
 var textUpdateTimeoutSecond = 30; // 音声認識結果が更新されない場合にクリアするまでの秒数（0以下の場合は自動クリアしない）
 
@@ -186,19 +187,14 @@ function vr_function() {
 
   recognition.onresult = function(event) {
     var results = event.results;
+    var current_transcripts = ''; // resultsが複数ある場合は全て連結する。
+    var need_reset = false;
     for (var i = event.resultIndex; i < results.length; i++) {
       if (results[i].isFinal) {
-        var result_transcript = results[i][0].transcript
+        last_finished = results[i][0].transcript;
         if (lang == 'ja-JP') {
-          result_transcript += '。';
+          last_finished += '。';
         }
-
-        if (document.getElementById('checkbox_hiragana').checked && lang == 'ja-JP') {
-          document.getElementById('result_text').innerHTML = resultToHiragana(result_transcript);
-        } else {
-          document.getElementById('result_text').innerHTML = result_transcript;
-        }
-        setTimeoutForClearText();
 
         if (document.getElementById('checkbox_timestamp').checked) {
           // タイムスタンプ機能
@@ -214,22 +210,26 @@ function vr_function() {
           result_transcript = timestamp + result_transcript
         }
 
-        document.getElementById('result_log').insertAdjacentHTML('beforeend', result_transcript + '\n');
+        document.getElementById('result_log').insertAdjacentHTML('beforeend', last_finished + '\n');
         textAreaHeightSet(document.getElementById('result_log'));
-        vr_function();
+        need_reset = true;
         flag_speech = 0;
       } else {
-        var result_transcript = results[i][0].transcript;
-
-        if (document.getElementById('checkbox_hiragana').checked && lang == 'ja-JP') {
-          document.getElementById('result_text').innerHTML = resultToHiragana(result_transcript);
-        } else {
-          document.getElementById('result_text').innerHTML = result_transcript;
-        }
-
+        current_transcripts += results[i][0].transcript;
         flag_speech = 1;
       }
     }
+
+    if (document.getElementById('checkbox_hiragana').checked && lang == 'ja-JP') {
+      document.getElementById('result_text').innerHTML 
+        = [resultToHiragana(last_finished), resultToHiragana(current_transcripts)].join('<br>');
+    } else {
+      document.getElementById('result_text').innerHTML 
+        = [last_finished, current_transcripts].join('<br>');
+    }
+    setTimeoutForClearText();
+
+    if (need_reset) { vr_function(); }
   }
 
   flag_speech = 0;
@@ -263,6 +263,7 @@ function setTimeoutForClearText() {
   textUpdateTimeoutID = setTimeout(
     () => {
       document.getElementById('result_text').innerHTML = "";
+      last_finished = ''; // 前回の確定結果もクリアする。
       textUpdateTimeoutID = 0;
     },
     textUpdateTimeoutSecond * 1000);
@@ -752,6 +753,7 @@ function initKuromoji(checkbox) {
 
 // 結果をひらがなにする
 function resultToHiragana(text) {
+  if (text == null || text.length === 0) return '';
   if (kuromojiObj == undefined) {
     return text;
   }


### PR DESCRIPTION
音声認識を実際に使っていると、時々字幕が切れて、非常に短くなります。
これは次の2つの要素からなるようです。

- 音声認識の途中の段階で、結果が複数に分裂する場合がある（また結合することもある）が、現状では複数になった場合に**最後の結果だけ**を表示している。
- 音声認識が確定した時（`SpeechRecognition.results[ix].isFinal === true` の場合）に、`vr_function`を呼び出して全てを作り直すため、せっかくの確定結果が字幕表示から消えてしまう。

これらを改善したのが、本PRです。一応、自分のテストページではうまく動作しています。

課題要素への対応は次のようにしています。

- 音声認識結果は全て文字列結合してから表示する（コードでは`current_transcripts`）。
- 音声認識が確定した時、その文字列を保持しておき（`last_finished`）、字幕上は「最後に確定した文字列＋。」＋brタグ＋「現状で未確定の認識結果」として表示する。
