### PR TITLE
対応ブラウザの拡大

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Web Speech API の音声認識を利用して文字起こしした結果をWeb�
 
 # デモページ
 https://1heisuzuki.github.io/speech-to-text-webcam-overlay/  
-*PC版のGoogle Chromeでアクセスしてください。
+*PC版のGoogle ChromeやMicrosoft Edgeのような音声認識をサポートするブラウザでアクセスしてください。Safariは2022年10月現在、挙動が不安定なので非推奨です。
 
 **目次**
 - [動作環境](#動作環境)
@@ -22,10 +22,14 @@ https://1heisuzuki.github.io/speech-to-text-webcam-overlay/
 かなりざっくりとした動作環境しか行っていません。  
 同様の環境で動かない場合はブラウザのアップデートや別ブラウザでの利用等をお試しください。
 
-- PC版 Google Chrome / Chromium / Vivaldi
+- PC版 Google Chrome
   - Windows, macOS, Linux (Ubuntu Mate 20.04) などで確認済み
+- PC版 Microsoft Edge
+  - Windows, macOSで動作することを確認（Linuxは2022年10月現在クラッシュする模様）
+- macOS版 Safari
+  - 一応動作するものの、同じ文言が二重で出たり認識が止まるなど、挙動が不安定
 - Android版 Google Chrome
-  - 筆者が端末を所持していないため未検証だが，動いたとの情報あり  
+  - 筆者が端末を所持していないため未検証だが，動いたとの情報あり（2022年10月現在、音声認識が適切に動作しない模様）
 
 # 何ができるか
 - 音声からリアルタイムで文字起こしを行い，Webカメラの映像に重ねてブラウザ上で表示する

--- a/index.html
+++ b/index.html
@@ -237,7 +237,7 @@
   <script src="kuromoji/build/kuromoji.js" defer></script>
   <!-- Chrome で MediaDevices.enumerateDevices() を動かすためのpolyfill -->
   <script src="https://webrtc.github.io/adapter/adapter-latest.js" defer></script>
-  <script src="./main.js?v=202109230545" defer></script>
+  <script src="./main.js?v=202210222000" defer></script>
 </body>
 
 </html>

--- a/main.js
+++ b/main.js
@@ -260,7 +260,8 @@ function vr_function() {
     for (var i = event.resultIndex; i < results.length; i++) {
       if (results[i].isFinal) {
         last_finished = results[i][0].transcript;
-        if (lang == 'ja-JP') {
+        const is_end_of_sentence = last_finished.endsWith('。') || last_finished.endsWith('？') || last_finished.endsWith('！');
+        if (lang == 'ja-JP' && is_end_of_sentence != true) {
           last_finished += '。';
         }
 


### PR DESCRIPTION
現在、本リポジトリは意図としては「Chrome以外は非対応としてエラーを出力」としています。しかし、次の問題があります。

- 他のブラウザでも音声認識APIはある程度は動作します。少なくとも現行版EdgeはChromeと遜色ない水準であり、Windowsデフォルトブラウザなので許容したいところです。
  - 現状のブラウザ判定コードは、現行版EdgeをChromeと判定しているので結果的には正しいのですが、意図とコードが食い違うのは混乱の元かと思います。
- 現行版Edgeの音声認識は、文末に自動的に「。」や「？」をつけてくれます。それ自体はいいのですが、あいにく現状の「自動的にマルをつける」処理と重複します（「。。」とか「？。」になってしまう）。

これらに対して、より正確なブラウザ判定をつけつつも、アプリ内ブラウザとFirefoxのような音声認識非対応を明確に示す（音声認識オブジェクトが存在しない）ブラウザだけエラーを出す形に変更してみました。また、Edgeが「。」「？」をつけてくれる件については、末尾が「。」「？」「！」だったら「。」はつけない、という形で対応してみました。

実際に動かすと、macのSafariは不安定（音声認識結果が二重になったり、止まったりなど）だったので、Safariの場合だけ警告をalert文で出しています。

こちらで動かした時の結果は次の通りです。

- Windows：ChromeおよびEdgeで問題なく動作する。
- macOS：Chromeは動作。Edgeは初回落ちたが2回目からは正常に動作。Safariは上述のように不安定。
- Linux：Chromeは動作。Edgeは読み込み後クラッシュしてしまう。
- iOS：Safariはカメラが写らないが音声認識は出る（macよりマシなような）。Chromeなどは音声認識が動作しない。
- Android：ChromeおよびEdgeで音声認識させると、音声認識開始の効果音が次々と鳴る一方で実際の認識は一切なされない。

なお、以前動作するとしていたChromiumやVivaldiは動作しなくなっています。この辺を踏まえてreadmeにおける対応ブラウザの記述も更新してみました。

動作確認は下記で行っています。
https://sksthrs.github.io/speech-to-text-webcam-overlay/